### PR TITLE
Adapt ImgFactory and NativeType changes in imglib2 core 5.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>org.scijava</groupId>
-		<artifactId>pom-scijava</artifactId>
-		<version>16.1.0</version>
+		<groupId>net.imglib2</groupId>
+		<artifactId>pom-imglib2</artifactId>
+		<version>10.0.2</version>
 	</parent>
 
 	<groupId>net.imglib2</groupId>
@@ -94,13 +94,17 @@ Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
 Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
 Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
 Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
+
+		<imglib2.version>5.1.0</imglib2.version>
+		<imglib2-cache.version>1.0.0-beta-8</imglib2-cache.version>
+		<bigdataviewer-core.version>5.0.0</bigdataviewer-core.version>
+		<bigdataviewer-vistools.version>1.0.0-beta-11</bigdataviewer-vistools.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-			<version>4.3.0</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -109,7 +113,6 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-cache</artifactId>
-			<version>1.0.0-beta-7</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
@@ -126,7 +129,7 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>org.scijava</groupId>
 			<artifactId>ui-behaviour</artifactId>
-			<version>1.3.0</version>
+			<version>1.7.3</version>
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
@@ -135,7 +138,6 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 		<dependency>
 			<groupId>nz.ac.waikato.cms.weka</groupId>
 			<artifactId>weka-dev</artifactId>
-			<version>3.9.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>

--- a/src/main/java/net/imglib2/cache/example01/Example01.java
+++ b/src/main/java/net/imglib2/cache/example01/Example01.java
@@ -26,8 +26,8 @@ public class Example01
 	{
 		final long[] dimensions = new long[] { 640, 640, 640 };
 
-		final Img< ARGBType > img = new DiskCachedCellImgFactory< ARGBType >()
-				.create( dimensions, new ARGBType() );
+		final Img< ARGBType > img = new DiskCachedCellImgFactory<>( new ARGBType() )
+				.create( dimensions );
 
 		ImageJFunctions.show( img );
 

--- a/src/main/java/net/imglib2/cache/example02/Example02.java
+++ b/src/main/java/net/imglib2/cache/example02/Example02.java
@@ -40,9 +40,8 @@ public class Example02
 
 		final CellLoader< ARGBType > loader = new CheckerboardLoader( new CellGrid( dimensions, cellDimensions ) );
 
-		final Img< ARGBType > img = new DiskCachedCellImgFactory< ARGBType >( options ).create(
+		final Img< ARGBType > img = new DiskCachedCellImgFactory<>( new ARGBType(), options ).create(
 				dimensions,
-				new ARGBType(),
 				loader );
 
 		ImageJFunctions.show( img );

--- a/src/main/java/net/imglib2/cache/example03/Example03.java
+++ b/src/main/java/net/imglib2/cache/example03/Example03.java
@@ -1,7 +1,7 @@
 package net.imglib2.cache.example03;
 
-import static net.imglib2.cache.img.AccessFlags.DIRTY;
-import static net.imglib2.cache.img.PrimitiveType.SHORT;
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.type.PrimitiveType.SHORT;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -21,6 +21,7 @@ import net.imglib2.cache.img.LoadedCellCacheLoader;
 import net.imglib2.cache.img.SingleCellArrayImg;
 import net.imglib2.cache.ref.GuardedStrongRefLoaderRemoverCache;
 import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.AccessFlags;
 import net.imglib2.img.basictypeaccess.array.DirtyShortArray;
 import net.imglib2.img.cell.Cell;
 import net.imglib2.img.cell.CellGrid;
@@ -72,12 +73,12 @@ public class Example03
 		final Path blockcache = DiskCellCache.createTempDirectory( "CellImg", true );
 		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
 		final CellLoader< UnsignedShortType > cellLoader = new CheckerboardLoader( grid );
-		final CacheLoader< Long, Cell< DirtyShortArray > > cacheLoader = LoadedCellCacheLoader.get( grid, cellLoader, type, DIRTY );
+		final CacheLoader< Long, Cell< DirtyShortArray > > cacheLoader = LoadedCellCacheLoader.get( grid, cellLoader, type, AccessFlags.setOf( DIRTY ) );
 		final DiskCellCache< DirtyShortArray > diskcache = new DirtyDiskCellCache<>(
 				blockcache,
 				grid,
 				cacheLoader,
-				AccessIo.get( SHORT, DIRTY ),
+				AccessIo.get( SHORT, AccessFlags.setOf( DIRTY ) ),
 				entitiesPerPixel );
 		final IoSync< Long, Cell< DirtyShortArray > > iosync = new IoSync<>( diskcache );
 		final Cache< Long, Cell< DirtyShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< DirtyShortArray > >( 100 )

--- a/src/main/java/net/imglib2/cache/example04/Example04.java
+++ b/src/main/java/net/imglib2/cache/example04/Example04.java
@@ -67,22 +67,22 @@ public class Example04
 		final long[] dimensions = new long[] { 640, 640, 640 };
 
 		final CheckerboardLoader loader = new CheckerboardLoader( new CellGrid( dimensions, cellDimensions ) );
-		final Img< UnsignedShortType > img = new DiskCachedCellImgFactory< UnsignedShortType >( options()
+		final Img< UnsignedShortType > img = new DiskCachedCellImgFactory<>( new UnsignedShortType(), options()
 				.cellDimensions( cellDimensions )
 				.cacheType( CacheType.BOUNDED )
 				.maxCacheSize( 100 ) )
-						.create( dimensions, new UnsignedShortType(), loader );
+						.create( dimensions, loader );
 
 		final Bdv bdv = BdvFunctions.show( img, "Cached" );
 		bdv.getBdvHandle().getViewerPanel().setDisplayMode( SINGLE );
 
 		final GaussLoader loader2 = new GaussLoader( Views.extendBorder( img ) );
-		final Img< UnsignedShortType > img2 = new DiskCachedCellImgFactory< UnsignedShortType >( options()
+		final Img< UnsignedShortType > img2 = new DiskCachedCellImgFactory<>( new UnsignedShortType(), options()
 				.cellDimensions( cellDimensions )
 				.cacheType( CacheType.BOUNDED )
 				.maxCacheSize( 100 )
 				.initializeCellsAsDirty( true ) )
-						.create( dimensions, new UnsignedShortType(), loader2 );
+						.create( dimensions, loader2 );
 
 		BdvFunctions.show( img2, "Gauss", BdvOptions.options().addTo( bdv ) );
 	}

--- a/src/main/java/net/imglib2/cache/example05/Example05.java
+++ b/src/main/java/net/imglib2/cache/example05/Example05.java
@@ -53,13 +53,13 @@ public class Example05
 		final long[] dimensions = new long[] { 640, 640, 640 };
 
 		final UnsignedShortType type = new UnsignedShortType();
-		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( options()
+		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( type, options()
 				.cellDimensions( cellDimensions )
 				.cacheType( CacheType.BOUNDED )
 				.maxCacheSize( 100 ) );
 
 		final CheckerboardLoader loader = new CheckerboardLoader( new CellGrid( dimensions, cellDimensions ) );
-		final Img< UnsignedShortType > img = factory.create( dimensions, type, loader );
+		final Img< UnsignedShortType > img = factory.create( dimensions, loader );
 		final Bdv bdv = BdvFunctions.show( img, "Cached" );
 		bdv.getBdvHandle().getViewerPanel().setDisplayMode( SINGLE );
 
@@ -67,8 +67,8 @@ public class Example05
 		final RandomAccessible< UnsignedShortType > source = Views.extendBorder( img );
 		final double[] sigma1 = new double[] { 5, 5, 5 };
 		final double[] sigma2 = new double[] { 4, 4, 4 };
-		final Img< UnsignedShortType > gauss1 = factory.create( dimensions, type, cell -> Gauss3.gauss( sigma1, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
-		final Img< UnsignedShortType > gauss2 = factory.create( dimensions, type, cell -> Gauss3.gauss( sigma2, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
+		final Img< UnsignedShortType > gauss1 = factory.create( dimensions, cell -> Gauss3.gauss( sigma1, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
+		final Img< UnsignedShortType > gauss2 = factory.create( dimensions, cell -> Gauss3.gauss( sigma2, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
 
 //		BdvFunctions.show( gauss1, "Gauss 1", BdvOptions.options().addTo( bdv ) );
 //		BdvFunctions.show( gauss2, "Gauss 2", BdvOptions.options().addTo( bdv ) );

--- a/src/main/java/net/imglib2/cache/example06/Example06.java
+++ b/src/main/java/net/imglib2/cache/example06/Example06.java
@@ -62,10 +62,10 @@ public class Example06
 				.cellDimensions( cellDimensions )
 				.cacheType( CacheType.BOUNDED )
 				.maxCacheSize( 100 );
-		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( factoryOptions );
+		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( type, factoryOptions );
 
 		final CheckerboardLoader loader = new CheckerboardLoader( new CellGrid( dimensions, cellDimensions ) );
-		final Img< UnsignedShortType > img = factory.create( dimensions, type, loader );
+		final Img< UnsignedShortType > img = factory.create( dimensions, loader );
 
 		final Bdv bdv = BdvFunctions.show( img, "Cached" );
 		bdv.getBdvHandle().getViewerPanel().setDisplayMode( SINGLE );
@@ -73,12 +73,12 @@ public class Example06
 		final RandomAccessible< UnsignedShortType > source = Views.extendBorder( img );
 		final double[] sigma1 = new double[] { 5, 5, 5 };
 		final double[] sigma2 = new double[] { 4, 4, 4 };
-		final Img< UnsignedShortType > gauss1 = factory.create( dimensions, type, cell -> Gauss3.gauss( sigma1, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
-		final Img< UnsignedShortType > gauss2 = factory.create( dimensions, type, cell -> Gauss3.gauss( sigma2, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
+		final Img< UnsignedShortType > gauss1 = factory.create( dimensions, cell -> Gauss3.gauss( sigma1, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
+		final Img< UnsignedShortType > gauss2 = factory.create( dimensions, cell -> Gauss3.gauss( sigma2, source, cell, 1 ), options().initializeCellsAsDirty( true ) );
 
-		final DiskCachedCellImgFactory< ShortType > sfactory = new DiskCachedCellImgFactory<>( factoryOptions );
-//		final Img< ShortType > diff = sfactory.create( dimensions, stype, cell -> Views.interval( Views.pair( cell, Views.pair( gauss1, gauss2 ) ), cell ).forEach( a -> a.getA().set( ( short ) ( a.getB().getA().get() - a.getB().getB().get() + 65535 / 4 ) ) ) );
-		final Img< ShortType > diff = sfactory.create( dimensions, stype, cell -> {
+		final DiskCachedCellImgFactory< ShortType > sfactory = new DiskCachedCellImgFactory<>( stype, factoryOptions );
+//		final Img< ShortType > diff = sfactory.create( dimensions, cell -> Views.interval( Views.pair( cell, Views.pair( gauss1, gauss2 ) ), cell ).forEach( a -> a.getA().set( ( short ) ( a.getB().getA().get() - a.getB().getB().get() + 65535 / 4 ) ) ) );
+		final Img< ShortType > diff = sfactory.create( dimensions, cell -> {
 			final Cursor< UnsignedShortType > in1 = Views.flatIterable( Views.interval( gauss1, cell ) ).cursor();
 			final Cursor< UnsignedShortType > in2 = Views.flatIterable( Views.interval( gauss2, cell ) ).cursor();
 			final Cursor< ShortType > out = Views.flatIterable( cell ).cursor();

--- a/src/main/java/net/imglib2/cache/exampleOps/ExampleOps.java
+++ b/src/main/java/net/imglib2/cache/exampleOps/ExampleOps.java
@@ -59,15 +59,15 @@ public class ExampleOps
 				.cellDimensions( cellDimensions )
 				.cacheType( CacheType.BOUNDED )
 				.maxCacheSize( 100 );
-		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( writeOnlyDirtyOptions );
+		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( type, writeOnlyDirtyOptions );
 
 		final CheckerboardLoader loader = new CheckerboardLoader( new CellGrid( dimensions, cellDimensions ) );
-		final Img< UnsignedShortType > img = factory.create( dimensions, type, loader );
+		final Img< UnsignedShortType > img = factory.create( dimensions, loader );
 
 		final Bdv bdv = BdvFunctions.show( img, "Cached" );
 		bdv.getBdvHandle().getViewerPanel().setDisplayMode( SINGLE );
 
-		final Img< UnsignedShortType > erode = factory.create( dimensions, type,
+		final Img< UnsignedShortType > erode = factory.create( dimensions,
 				cell -> ij.op().morphology().erode( cell, img, new RectangleShape( 3, false ) ),
 				options().initializeCellsAsDirty( true ) );
 

--- a/src/main/java/net/imglib2/cache/exampleclassifier/ExampleClassifyingCell.java
+++ b/src/main/java/net/imglib2/cache/exampleclassifier/ExampleClassifyingCell.java
@@ -86,19 +86,19 @@ public class ExampleClassifyingCell
 
 		final UnsignedShortType type = new UnsignedShortType();
 
-		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory< UnsignedShortType >( options()
+		final DiskCachedCellImgFactory< UnsignedShortType > factory = new DiskCachedCellImgFactory<>( type, options()
 				.cellDimensions( cellDimensions )
 				.cacheType( CacheType.BOUNDED )
 				.maxCacheSize( 100 ) );
 
 		final CheckerboardLoader loader = new CheckerboardLoader( new CellGrid( dimensions, cellDimensions ) );
-		final Img< UnsignedShortType > img = factory.create( dimensions, type, loader );
+		final Img< UnsignedShortType > img = factory.create( dimensions, loader );
 
 		final Bdv bdv = BdvFunctions.show( img, "Cached" );
 		bdv.getBdvHandle().getViewerPanel().setDisplayMode( SINGLE );
 
 		final ThresholdingClassifier classifier = new ThresholdingClassifier( 0.5 );
-		final Img< UnsignedShortType > prediction = factory.create( dimensions, type,
+		final Img< UnsignedShortType > prediction = factory.create( dimensions,
 				new ClassifyingCellLoader<>( Arrays.asList( img ), classifier, 2 ),
 				options().initializeCellsAsDirty( true ) );
 

--- a/src/main/java/net/imglib2/cache/examplehttp/ExampleHTTP.java
+++ b/src/main/java/net/imglib2/cache/examplehttp/ExampleHTTP.java
@@ -81,8 +81,8 @@ public class ExampleHTTP
 				.maxCacheSize( 1000 )
 				.cellDimensions( cellDimensions );
 
-		final Img< UnsignedByteType > httpImg = new DiskCachedCellImgFactory< UnsignedByteType >( factoryOptions )
-				.createWithCacheLoader( dimensions, new UnsignedByteType(), loader );
+		final Img< UnsignedByteType > httpImg = new DiskCachedCellImgFactory<>( new UnsignedByteType(), factoryOptions )
+				.createWithCacheLoader( dimensions, loader );
 
 		final RandomAccessible< FloatType > source = Converters.convert( Views.extendBorder( httpImg ), new RealFloatConverter<>(), new FloatType() );
 		final CellLoader< FloatType > gradientLoader = new CellLoader< FloatType >()
@@ -107,8 +107,8 @@ public class ExampleHTTP
 			}
 		};
 
-		final Img< FloatType > gradientImg = new DiskCachedCellImgFactory< FloatType >( factoryOptions )
-				.create( dimensions, new FloatType(), gradientLoader,
+		final Img< FloatType > gradientImg = new DiskCachedCellImgFactory<>( new FloatType(), factoryOptions )
+				.create( dimensions, gradientLoader,
 						options().initializeCellsAsDirty( true ) );
 
 		final BdvSource httpSource = BdvFunctions.show(

--- a/src/main/java/net/imglib2/cache/lowlevel/example03/Example03.java
+++ b/src/main/java/net/imglib2/cache/lowlevel/example03/Example03.java
@@ -1,7 +1,7 @@
 package net.imglib2.cache.lowlevel.example03;
 
-import static net.imglib2.cache.img.AccessFlags.DIRTY;
-import static net.imglib2.cache.img.PrimitiveType.SHORT;
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.type.PrimitiveType.SHORT;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -17,6 +17,7 @@ import net.imglib2.cache.img.DirtyDiskCellCache;
 import net.imglib2.cache.img.DiskCellCache;
 import net.imglib2.cache.ref.GuardedStrongRefLoaderRemoverCache;
 import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.AccessFlags;
 import net.imglib2.img.basictypeaccess.array.DirtyShortArray;
 import net.imglib2.img.cell.Cell;
 import net.imglib2.img.cell.CellGrid;
@@ -75,7 +76,7 @@ public class Example03
 				blockcache,
 				grid,
 				new CheckerboardLoader( grid ),
-				AccessIo.get( SHORT, DIRTY ),
+				AccessIo.get( SHORT, AccessFlags.setOf( DIRTY ) ),
 				entitiesPerPixel );
 		final IoSync< Long, Cell< DirtyShortArray > > iosync = new IoSync<>( diskcache );
 		final UncheckedCache< Long, Cell< DirtyShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< DirtyShortArray > >( 100 )

--- a/src/main/java/net/imglib2/cache/lowlevel/example04/Example04.java
+++ b/src/main/java/net/imglib2/cache/lowlevel/example04/Example04.java
@@ -1,8 +1,8 @@
 package net.imglib2.cache.lowlevel.example04;
 
 import static bdv.viewer.DisplayMode.SINGLE;
-import static net.imglib2.cache.img.AccessFlags.DIRTY;
-import static net.imglib2.cache.img.PrimitiveType.SHORT;
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.type.PrimitiveType.SHORT;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -22,6 +22,7 @@ import net.imglib2.cache.img.DiskCellCache;
 import net.imglib2.cache.ref.GuardedStrongRefLoaderRemoverCache;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.AccessFlags;
 import net.imglib2.img.basictypeaccess.array.DirtyShortArray;
 import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.img.cell.Cell;
@@ -115,7 +116,7 @@ public class Example04
 				blockcache,
 				grid,
 				new CheckerboardLoader( grid ),
-				AccessIo.get( SHORT, DIRTY ),
+				AccessIo.get( SHORT, AccessFlags.setOf( DIRTY ) ),
 				entitiesPerPixel );
 		final IoSync< Long, Cell< DirtyShortArray > > iosync = new IoSync<>( diskcache );
 		final UncheckedCache< Long, Cell< DirtyShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< DirtyShortArray > >( 100 )
@@ -132,7 +133,7 @@ public class Example04
 				blockcache2,
 				grid,
 				new GaussLoader( grid, Views.extendBorder( img ) ),
-				AccessIo.get( SHORT ),
+				AccessIo.get( SHORT, AccessFlags.setOf() ),
 				entitiesPerPixel );
 		final IoSync< Long, Cell< ShortArray > > iosync2 = new IoSync<>( diskcache2 );
 		final UncheckedCache< Long, Cell< ShortArray > > cache2 = new GuardedStrongRefLoaderRemoverCache< Long, Cell< ShortArray > >( 100 )

--- a/src/main/java/net/imglib2/cache/lowlevel/example05/Example05.java
+++ b/src/main/java/net/imglib2/cache/lowlevel/example05/Example05.java
@@ -1,9 +1,9 @@
 package net.imglib2.cache.lowlevel.example05;
 
 import static bdv.viewer.DisplayMode.SINGLE;
-import static net.imglib2.cache.img.AccessFlags.DIRTY;
-import static net.imglib2.cache.img.AccessFlags.VOLATILE;
-import static net.imglib2.cache.img.PrimitiveType.SHORT;
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.img.basictypeaccess.AccessFlags.VOLATILE;
+import static net.imglib2.type.PrimitiveType.SHORT;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -36,6 +36,7 @@ import net.imglib2.cache.volatiles.LoadingStrategy;
 import net.imglib2.cache.volatiles.VolatileCache;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.AccessFlags;
 import net.imglib2.img.basictypeaccess.array.DirtyShortArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileShortArray;
 import net.imglib2.img.cell.Cell;
@@ -141,7 +142,7 @@ public class Example05
 				blockcache,
 				grid,
 				new GaussLoader( grid, source, sigma ),
-				AccessIo.get( SHORT, VOLATILE ),
+				AccessIo.get( SHORT, AccessFlags.setOf( VOLATILE ) ),
 				type.getEntitiesPerPixel() );
 		final IoSync< Long, Cell< VolatileShortArray > > iosync = new IoSync<>( diskcache );
 		final Cache< Long, Cell< VolatileShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< VolatileShortArray > >( 1000 )
@@ -149,7 +150,7 @@ public class Example05
 				.withLoader( iosync );
 		final Img< UnsignedShortType > gauss = new LazyCellImg<>( grid, new UnsignedShortType(), cache.unchecked()::get );
 
-		final CreateInvalid< Long, Cell< VolatileShortArray > > createInvalid = CreateInvalidVolatileCell.get( grid, type );
+		final CreateInvalid< Long, Cell< VolatileShortArray > > createInvalid = CreateInvalidVolatileCell.get( grid, type, false );
 		final VolatileCache< Long, Cell< VolatileShortArray > > volatileCache = new WeakRefVolatileCache<>( cache, queue, createInvalid );
 
 		final CacheHints hints = new CacheHints( LoadingStrategy.VOLATILE, 0, false );
@@ -173,7 +174,7 @@ public class Example05
 				blockcache,
 				grid,
 				new CheckerboardLoader( grid ),
-				AccessIo.get( SHORT, DIRTY ),
+				AccessIo.get( SHORT, AccessFlags.setOf( DIRTY ) ),
 				type.getEntitiesPerPixel() );
 		final IoSync< Long, Cell< DirtyShortArray > > iosync = new IoSync<>( diskcache );
 		final UncheckedCache< Long, Cell< DirtyShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< DirtyShortArray > >( 1000 )

--- a/src/main/java/net/imglib2/cache/lowlevel/example06/Example06.java
+++ b/src/main/java/net/imglib2/cache/lowlevel/example06/Example06.java
@@ -1,9 +1,9 @@
 package net.imglib2.cache.lowlevel.example06;
 
 import static bdv.viewer.DisplayMode.SINGLE;
-import static net.imglib2.cache.img.AccessFlags.DIRTY;
-import static net.imglib2.cache.img.AccessFlags.VOLATILE;
-import static net.imglib2.cache.img.PrimitiveType.SHORT;
+import static net.imglib2.img.basictypeaccess.AccessFlags.DIRTY;
+import static net.imglib2.img.basictypeaccess.AccessFlags.VOLATILE;
+import static net.imglib2.type.PrimitiveType.SHORT;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -34,6 +34,7 @@ import net.imglib2.cache.volatiles.LoadingStrategy;
 import net.imglib2.cache.volatiles.VolatileCache;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.AccessFlags;
 import net.imglib2.img.basictypeaccess.array.DirtyShortArray;
 import net.imglib2.img.basictypeaccess.volatiles.array.VolatileShortArray;
 import net.imglib2.img.cell.Cell;
@@ -134,7 +135,7 @@ public class Example06
 				blockcache,
 				grid,
 				new GaussLoader( grid, source, sigma ),
-				AccessIo.get( SHORT, VOLATILE ),
+				AccessIo.get( SHORT, AccessFlags.setOf( VOLATILE ) ),
 				type.getEntitiesPerPixel() );
 		final IoSync< Long, Cell< VolatileShortArray > > iosync = new IoSync<>( diskcache );
 		final Cache< Long, Cell< VolatileShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< VolatileShortArray > >( 1000 )
@@ -142,7 +143,7 @@ public class Example06
 				.withLoader( iosync );
 		final Img< UnsignedShortType > gauss = new LazyCellImg<>( grid, type, cache.unchecked()::get );
 
-		final CreateInvalid< Long, Cell< VolatileShortArray > > createInvalid = CreateInvalidVolatileCell.get( grid, type );
+		final CreateInvalid< Long, Cell< VolatileShortArray > > createInvalid = CreateInvalidVolatileCell.get( grid, type, false );
 		final VolatileCache< Long, Cell< VolatileShortArray > > volatileCache = new WeakRefVolatileCache<>( cache, queue, createInvalid );
 
 		final CacheHints hints = new CacheHints( LoadingStrategy.VOLATILE, 0, false );
@@ -204,7 +205,7 @@ public class Example06
 				blockcache,
 				grid,
 				new DiffLoader( grid, source1, source2 ),
-				AccessIo.get( SHORT, VOLATILE ),
+				AccessIo.get( SHORT, AccessFlags.setOf( VOLATILE ) ),
 				type.getEntitiesPerPixel() );
 		final IoSync< Long, Cell< VolatileShortArray > > iosync = new IoSync<>( diskcache );
 		final Cache< Long, Cell< VolatileShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< VolatileShortArray > >( 1000 )
@@ -212,7 +213,7 @@ public class Example06
 				.withLoader( iosync );
 		final Img< ShortType > gauss = new LazyCellImg<>( grid, type, cache.unchecked()::get );
 
-		final CreateInvalid< Long, Cell< VolatileShortArray > > createInvalid = CreateInvalidVolatileCell.get( grid, type );
+		final CreateInvalid< Long, Cell< VolatileShortArray > > createInvalid = CreateInvalidVolatileCell.get( grid, type, false );
 		final VolatileCache< Long, Cell< VolatileShortArray > > volatileCache = new WeakRefVolatileCache<>( cache, queue, createInvalid );
 
 		final CacheHints hints = new CacheHints( LoadingStrategy.VOLATILE, 0, false );
@@ -237,7 +238,7 @@ public class Example06
 				blockcache,
 				grid,
 				new CheckerboardLoader( grid ),
-				AccessIo.get( SHORT, DIRTY ),
+				AccessIo.get( SHORT, AccessFlags.setOf( DIRTY ) ),
 				type.getEntitiesPerPixel() );
 		final IoSync< Long, Cell< DirtyShortArray > > iosync = new IoSync<>( diskcache );
 		final UncheckedCache< Long, Cell< DirtyShortArray > > cache = new GuardedStrongRefLoaderRemoverCache< Long, Cell< DirtyShortArray > >( 1000 )


### PR DESCRIPTION
 * Adapt changes in bdv-core: Replace AccessFlags... parameter by boolean dirty
 * Revise imports
 * Fix use of deprecated ImgFactory constructors and create() methods